### PR TITLE
increase state timeout to 65 mins to avoid getting "in-sync" with home assistant requests

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ const uint8_t MCP_COUNT             = sizeof(MCP_I2C_ADDRESS);
 
 #define       KNX_RESET_TIMEOUT_MS  5000        // 5 seconds
 #define       KNX_READ_TIMEOUT_MS   5000        // 5 seconds
-#define       KNX_STATE_EXPIRY_MS   3600000     // 1 hour
+#define       KNX_STATE_EXPIRY_MS   3900000     // 65 minutes
 
 // Max number of supported inputs
 const uint8_t MAX_INPUT_COUNT       = MCP_COUNT * MCP_PIN_COUNT;


### PR DESCRIPTION
Home Assistant has a 60 min timeout before sending `GroupRead` requests. Previously we had the exact same timeout, meaning once a state change occurred, both us and HA would get in-sync and send the next `GroupRead` at exactly the same time.

We extend our timeout by 5 mins so that if you running alongside HA this firmware should never need to send any `GroupRead` requests, it will just consume the responses to the HA requests. 

But if HA is not present or goes down, we will still trigger regular `GroupRead` requests.