### PR TITLE
stop read state requests after 10 failed attempts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,13 +561,16 @@ void loopKnx()
     else
     {
       // Pop the next item off the queue
-      uint8_t idx = popQueue();
+      uint8_t i = popQueue();
   
-      // Send a status read request
-      knx.groupRead(g_knxConfig[idx].stateAddress);
+      if (i >= 0 && i < MAX_INPUT_COUNT)
+      {
+        // Send a status read request
+        knx.groupRead(g_knxConfig[i].stateAddress);
 
-      // Start the read wait timer
-      startReadWaitTimer(idx);
+        // Start the read wait timer
+        startReadWaitTimer(i);
+      }
     }
   }
   else


### PR DESCRIPTION
Changed the queue to store the index of the inputs we want to request status udpates for, instead of the GA address itself. Makes it easier to track the time out count for each individual input.

Should now keep count of each failed status read request and stop requesting after 10 failures.

If a device goes offline and causes this timeout to trigger, once the device comes back online it should reset the counter as soon as device reports any status change, e.g. from a physical switch on/off.